### PR TITLE
Rename .dmg for upload

### DIFF
--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -44,11 +44,13 @@ pipenv run pew package
 
 echo "--- Uploading"
 
-
+MACOS_VERSION_INDICATOR=$(git describe --exact-match --tags || git rev-parse --short HEAD)
 # Clear dist so that the dmg is in the same dir as the rest of the packages
-rm -r dist/* && mv package/osx/kolibri*.dmg dist/kolibri-$(more src/kolibri/VERSION)-$(git rev-parse --short HEAD).dmg
+rm -r dist/* && mv package/osx/kolibri*.dmg \
+  dist/kolibri-$(more src/kolibri/VERSION)-macos-$MACOS_VERSION_INDICATOR.dmg
 
 # Environment var doesn't exist my default, so we have to manually pass it.
-buildkite-agent artifact upload "dist/kolibri*.dmg" --job $(buildkite-agent meta-data get triggered_from_job_id --default $BUILDKITE_JOB_ID)
+buildkite-agent artifact upload "dist/kolibri*.dmg" \
+  --job $(buildkite-agent meta-data get triggered_from_job_id --default $BUILDKITE_JOB_ID)
 
 # TODO upload directly to google cloud

--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -46,7 +46,7 @@ echo "--- Uploading"
 
 
 # Clear dist so that the dmg is in the same dir as the rest of the packages
-rm -r dist/* && mv package/osx/kolibri*.dmg dist/
+rm -r dist/* && mv package/osx/kolibri*.dmg dist/kolibri-$(more src/kolibri/VERSION)-$(git rev-parse --short HEAD).dmg
 
 # Environment var doesn't exist my default, so we have to manually pass it.
 buildkite-agent artifact upload "dist/kolibri*.dmg" --job $(buildkite-agent meta-data get triggered_from_job_id --default $BUILDKITE_JOB_ID)


### PR DESCRIPTION
For buildkite-agent upload behaviour.

Does not touch actual package version at all.

Looks like this:
![macos filename](https://user-images.githubusercontent.com/9877852/69767901-3cd7c780-1133-11ea-9d45-70a9bcf879f6.png)

Bare-minimum to address
https://github.com/learningequality/kolibri/issues/6146
