### PR TITLE
Compile Kolibri Python code after pew build

### DIFF
--- a/build_tools/build.py
+++ b/build_tools/build.py
@@ -14,6 +14,7 @@ def do_build():
 
         stdlib.generate_stdlib_imports()
         subprocess.call(['pew', 'build'])
+        stdlib.generate_python_bytecode(kolibri_dest_dir)
 
     except Exception as e:
         raise e

--- a/build_tools/stdlib.py
+++ b/build_tools/stdlib.py
@@ -1,3 +1,4 @@
+import compileall
 import distutils.sysconfig as sysconfig
 import os
 import sys
@@ -32,6 +33,9 @@ if sys.platform.startswith('win'):
         'tty',
         'termios',
     ])
+
+def generate_python_bytecode(module_dir):
+    compileall.compile_dir(module_dir)
 
 def generate_stdlib_imports():
     """


### PR DESCRIPTION
With this change, the Kolibri Python code distributed with our pyeverywhere bundle will be accompanied by compatible Python bytecode, which should allow Python to load these modules faster. We still need to verify that this is a necessary change, but it is fairly innocuous. I contemplated adding this to pyeverywhere itself, but it feels like a very Kolibri-specific issue, so hopefully this will do the trick.