### PR TITLE
Fix Windows notification color inversion

### DIFF
--- a/src/kolibri_app/application.py
+++ b/src/kolibri_app/application.py
@@ -19,7 +19,7 @@ if WINDOWS:
     import win32gui
 
     from kolibri_app.server_manager_windows import WindowsServerManager as ServerManager
-    from kolibri_app.taskbar_icon import KolibriTaskBarIcon
+    from kolibri_app.windows.taskbar_icon import KolibriTaskBarIcon
     from kolibri_app.windows_registry import is_webview2_installed
 else:
     from kolibri.core.device.utils import app_initialize_url

--- a/src/kolibri_app/constants.py
+++ b/src/kolibri_app/constants.py
@@ -11,6 +11,12 @@ WINDOWS = sys.platform.startswith("win32")
 # Windows specific constants
 TRAY_ICON_ICO = "icons/kolibri.ico"
 SERVICE_NAME = "Kolibri"
+# Explicit AppUserModelID for notification attribution. Without it, Windows
+# auto-generates an identity for the tray icon and renders the notification
+# header from a cached copy of the tray HICON, which can show with swapped
+# colours (see issue #184). Registered in the registry with a DisplayName and
+# IconUri so toasts show "Kolibri" and the icon file directly.
+APP_USER_MODEL_ID = "LearningEquality.Kolibri"
 # Microsoft's official identifier for the WebView2 Runtime, used for registry checks.
 # Source: https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution?tabs=dotnetcsharp
 WEBVIEW2_RUNTIME_GUID = "{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}"

--- a/src/kolibri_app/windows/__init__.py
+++ b/src/kolibri_app/windows/__init__.py
@@ -1,0 +1,6 @@
+"""Windows-only components of the Kolibri app.
+
+Modules in this package import ``pywin32``/Win32 APIs at import time and must
+only be imported when running on Windows (guard with
+``kolibri_app.constants.WINDOWS``).
+"""

--- a/src/kolibri_app/windows/taskbar_icon.py
+++ b/src/kolibri_app/windows/taskbar_icon.py
@@ -1,24 +1,39 @@
 """
 Windows taskbar icon implementation for Kolibri App.
 
+Windows-only: imports pywin32/Win32 APIs at import time. Only import this module
+when ``kolibri_app.constants.WINDOWS`` is true.
+
 Provides system tray functionality:
 - Service and UI startup configuration
 - Server status notifications
 - Right-click context menu for common actions
 - Integration with Windows registry for startup settings
+
+The tray icon is driven directly through ``Shell_NotifyIcon`` rather than
+``wx.adv.TaskBarIcon``. wxPython's ``ShowBalloon`` cannot pass a balloon icon,
+so Windows falls back to XOR-drawing the tray ``HICON`` for the notification,
+which inverts the colours in light theme and looks low-res. Owning the
+``NOTIFYICONDATA`` lets us send ``NIIF_USER | NIIF_LARGE_ICON`` with a proper
+alpha icon, which the shell alpha-blends at full resolution (see issue #184).
+pywin32's ``Shell_NotifyIcon`` tuple stops at ``hIcon`` and cannot carry
+``hBalloonIcon``, so the notification is sent through a ctypes struct.
 """
 
 import ctypes
 import os
 import sys
 import webbrowser
+from ctypes import wintypes
 from importlib.resources import files
 
 import pywintypes
+import win32api
+import win32con
+import win32gui
 import win32service
 import winerror
 import wx
-from wx.adv import TaskBarIcon
 
 from kolibri_app.constants import APP_NAME
 from kolibri_app.constants import SERVICE_NAME
@@ -33,6 +48,66 @@ DEFAULT_NOTIFICATION_TIMEOUT = 5
 
 VERIFICATION_MAX_RETRIES = 15
 VERIFICATION_RETRY_INTERVAL_MS = 1000
+
+# Callback message the shell posts to our window for mouse events on the icon.
+WM_TRAY_CALLBACK = win32con.WM_USER + 20
+# Stable per-window identifier for our single tray icon.
+TRAY_ICON_ID = 1
+# Source size for the balloon icon; larger than the tray icon so the shell has a
+# high-res source to alpha-blend into the notification.
+BALLOON_ICON_SIZE = 128
+
+# NOTIFYICONDATA.uFlags
+NIF_MESSAGE = 0x01
+NIF_ICON = 0x02
+NIF_TIP = 0x04
+NIF_INFO = 0x10
+
+# Shell_NotifyIcon messages
+NIM_ADD = 0x00
+NIM_MODIFY = 0x01
+NIM_DELETE = 0x02
+
+# NOTIFYICONDATA.dwInfoFlags
+NIIF_USER = 0x04
+NIIF_LARGE_ICON = 0x20
+
+
+class _NOTIFYICONDATAW(ctypes.Structure):
+    _fields_ = [
+        ("cbSize", wintypes.DWORD),
+        ("hWnd", wintypes.HWND),
+        ("uID", wintypes.UINT),
+        ("uFlags", wintypes.UINT),
+        ("uCallbackMessage", wintypes.UINT),
+        ("hIcon", wintypes.HICON),
+        ("szTip", wintypes.WCHAR * 128),
+        ("dwState", wintypes.DWORD),
+        ("dwStateMask", wintypes.DWORD),
+        ("szInfo", wintypes.WCHAR * 256),
+        ("uVersion", wintypes.UINT),
+        ("szInfoTitle", wintypes.WCHAR * 64),
+        ("dwInfoFlags", wintypes.DWORD),
+        # guidItem is unused (icon is identified by uID); it only reserves the
+        # 16 bytes so cbSize spans through hBalloonIcon, the field that carries
+        # the Vista+ balloon icon.
+        ("guidItem", ctypes.c_byte * 16),
+        ("hBalloonIcon", wintypes.HICON),
+    ]
+
+
+_shell_notify_icon = ctypes.windll.shell32.Shell_NotifyIconW
+_shell_notify_icon.argtypes = [wintypes.DWORD, ctypes.POINTER(_NOTIFYICONDATAW)]
+_shell_notify_icon.restype = wintypes.BOOL
+
+
+def _new_nid(hwnd):
+    """Build a NOTIFYICONDATAW targeting our single icon."""
+    nid = _NOTIFYICONDATAW()
+    nid.cbSize = ctypes.sizeof(_NOTIFYICONDATAW)
+    nid.hWnd = hwnd
+    nid.uID = TRAY_ICON_ID
+    return nid
 
 
 def get_service_start_type():
@@ -75,31 +150,87 @@ def get_service_start_type():
             win32service.CloseServiceHandle(scm_handle)
 
 
-class KolibriTaskBarIcon(TaskBarIcon):
+class KolibriTaskBarIcon:
     def __init__(self, app):
-        super(KolibriTaskBarIcon, self).__init__()
         self.app = app
         self.server_starting_notified = (
             False  # Track if we've shown the starting notification
         )
+        self._added = False
+        self._old_wndproc = None
+        self._tray_hicon = None
+        self._balloon_hicon = None
 
-        self.Bind(wx.adv.EVT_TASKBAR_LEFT_DOWN, self.on_left_click)
+        # Hidden window that owns the tray icon and receives its callback
+        # messages. Never shown; FRAME_NO_TASKBAR keeps it off the taskbar.
+        self.frame = wx.Frame(None, title=f"{APP_NAME}_Tray", style=wx.FRAME_NO_TASKBAR)
+        self.hwnd = self.frame.GetHandle()
 
-        self.set_icon(TRAY_ICON_ICO, f"{APP_NAME}")
+        # Subclass the frame's window proc to intercept tray callbacks, chaining
+        # to wx's original proc so menus and other wx messages keep working.
+        self._old_wndproc = win32gui.SetWindowLong(
+            self.hwnd, win32con.GWL_WNDPROC, self._wndproc
+        )
 
-    def set_icon(self, path, tooltip):
-        """Sets the icon and tooltip for the taskbar icon."""
+        self._load_icons()
+        self._add_icon()
 
-        # 'path' is expected to be 'icons/kolibri.ico'
+    def _load_icon(self, path, size):
+        """Load the app icon from `path` at the requested pixel size."""
+        return win32gui.LoadImage(
+            0, path, win32con.IMAGE_ICON, size, size, win32con.LR_LOADFROMFILE
+        )
+
+    def _load_icons(self):
+        """Load the small tray icon and the larger balloon icon."""
         try:
-            # We need the absolute path for wx.Icon, so resolve() is necessary
-            icon_resource_path = files("kolibri_app") / path
-            final_path = str(icon_resource_path.resolve())
+            icon_path = str((files("kolibri_app") / TRAY_ICON_ICO).resolve())
+            small = win32api.GetSystemMetrics(win32con.SM_CXSMICON)
+            self._tray_hicon = self._load_icon(icon_path, small)
+            self._balloon_hicon = self._load_icon(icon_path, BALLOON_ICON_SIZE)
+        except (OSError, pywintypes.error) as e:
+            logging.error(f"Error loading tray icons: {e}")
 
-            icon = wx.Icon(final_path, wx.BITMAP_TYPE_ICO)
-            self.SetIcon(icon, tooltip)
-        except (FileNotFoundError, wx.wxAssertionError, OSError) as e:
-            logging.error(f"Error setting icon from path '{final_path}': {e}")
+    def _add_icon(self):
+        """Register the tray icon with the shell."""
+        nid = _new_nid(self.hwnd)
+        nid.uFlags = NIF_MESSAGE | NIF_ICON | NIF_TIP
+        nid.uCallbackMessage = WM_TRAY_CALLBACK
+        nid.hIcon = self._tray_hicon or 0
+        nid.szTip = APP_NAME
+        if _shell_notify_icon(NIM_ADD, ctypes.byref(nid)):
+            self._added = True
+        else:
+            logging.error("Shell_NotifyIcon NIM_ADD failed for the tray icon.")
+
+    def _remove_icon(self):
+        """Remove the tray icon from the shell."""
+        if not self._added:
+            return
+        _shell_notify_icon(NIM_DELETE, ctypes.byref(_new_nid(self.hwnd)))
+        self._added = False
+
+    def _wndproc(self, hwnd, msg, wparam, lparam):
+        """Window proc for the hidden tray window."""
+        if msg == WM_TRAY_CALLBACK:
+            # In classic (non-versioned) mode lParam is the mouse message.
+            if lparam == win32con.WM_LBUTTONUP:
+                wx.CallAfter(self.on_left_click)
+            elif lparam == win32con.WM_RBUTTONUP:
+                self._show_menu()
+            return 0
+        if msg == win32con.WM_DESTROY:
+            self._remove_icon()
+        return win32gui.CallWindowProc(self._old_wndproc, hwnd, msg, wparam, lparam)
+
+    def _show_menu(self):
+        """Show the right-click context menu at the cursor."""
+        # SetForegroundWindow is required so the menu dismisses when the user
+        # clicks elsewhere (see the TrackPopupMenu docs).
+        win32gui.SetForegroundWindow(self.hwnd)
+        menu = self.CreatePopupMenu()
+        self.frame.PopupMenu(menu)
+        menu.Destroy()
 
     def show_notification(self, title, message, timeout=DEFAULT_NOTIFICATION_TIMEOUT):
         """
@@ -111,10 +242,22 @@ class KolibriTaskBarIcon(TaskBarIcon):
             timeout: How long to show the notification (in seconds)
         """
         try:
-            # Create notification
-            self.ShowBalloon(title, message, timeout * 1000)
-
-        except (ImportError, AttributeError, OSError) as e:
+            nid = _new_nid(self.hwnd)
+            nid.uFlags = NIF_INFO
+            # szInfo/szInfoTitle are fixed WCHAR buffers (256/64); an over-long
+            # string raises ValueError, which the except below doesn't catch.
+            nid.szInfo = message[:255]
+            nid.szInfoTitle = title[:63]
+            nid.uVersion = timeout * 1000  # Ignored on Vista+, harmless to set.
+            # NIIF_USER + hBalloonIcon makes the shell alpha-blend our icon
+            # instead of XOR-drawing the tray icon (which inverts in light
+            # theme); NIIF_LARGE_ICON renders it at full resolution.
+            if self._balloon_hicon:
+                nid.dwInfoFlags = NIIF_USER | NIIF_LARGE_ICON
+                nid.hBalloonIcon = self._balloon_hicon
+            if not _shell_notify_icon(NIM_MODIFY, ctypes.byref(nid)):
+                raise OSError("Shell_NotifyIcon NIM_MODIFY failed")
+        except (OSError, pywintypes.error) as e:
             logging.error(f"Failed to show notification: {e}")
             # Fallback to a simple message box if notifications fail
             wx.CallAfter(wx.MessageBox, message, title, wx.OK | wx.ICON_INFORMATION)
@@ -141,23 +284,25 @@ class KolibriTaskBarIcon(TaskBarIcon):
         message = _("Kolibri failed to start.\nCheck logs at: {}").format(log_path)
         self.show_notification(_("Kolibri Error"), message, timeout=10)
 
-    def on_left_click(self, event):
+    def _show_window(self, main_window):
+        """Un-minimize, show, and raise the given main window."""
+        view = main_window.view
+        # If window is minimized, make it non-minimized.
+        if view.IsIconized():
+            view.Iconize(False)
+        # If the window is closed, show it.
+        if not view.IsShown():
+            view.Show()
+        # Always bring the window to the foreground.
+        view.Raise()
+
+    def on_left_click(self):
         """
         Handles left-click on the taskbar icon.
         """
         main_window = self.app.view
         if main_window:
-            view = main_window.view
-            # If window is minimized, make it non-minimized.
-            if view.IsIconized():
-                view.Iconize(False)
-
-            # If the window is closed, show it.
-            if not view.IsShown():
-                view.Show()
-
-            # Always bring the window to the foreground.
-            view.Raise()
+            self._show_window(main_window)
 
     def CreatePopupMenu(self):
         """Create and return the right-click menu."""
@@ -166,14 +311,14 @@ class KolibriTaskBarIcon(TaskBarIcon):
         # 1. Open UI
         open_item = menu.Append(wx.ID_ANY, _("Open UI"))
         open_item.Enable(bool(self.app.kolibri_url))
-        self.Bind(wx.EVT_MENU, self.on_open_ui, open_item)
+        self.frame.Bind(wx.EVT_MENU, self.on_open_ui, open_item)
 
         menu.AppendSeparator()
 
         # 2. Open kolibri UI on logon (Toggle) - Per-user setting
         startup_ui_item = menu.AppendCheckItem(wx.ID_ANY, _("Open Kolibri UI on logon"))
         startup_ui_item.Check(is_ui_startup_enabled())
-        self.Bind(wx.EVT_MENU, self.on_toggle_startup_ui, startup_ui_item)
+        self.frame.Bind(wx.EVT_MENU, self.on_toggle_startup_ui, startup_ui_item)
 
         # 3. Run Kolibri service on start (Toggle) - System-wide setting
         self.run_on_start_item = menu.AppendCheckItem(
@@ -187,13 +332,15 @@ class KolibriTaskBarIcon(TaskBarIcon):
             self.run_on_start_item.SetItemLabel(
                 _("Run Kolibri service on start (Unavailable)")
             )
-        self.Bind(wx.EVT_MENU, self.on_toggle_service_startup, self.run_on_start_item)
+        self.frame.Bind(
+            wx.EVT_MENU, self.on_toggle_service_startup, self.run_on_start_item
+        )
 
         menu.AppendSeparator()
 
         # 4. Exit
         exit_item = menu.Append(wx.ID_EXIT, _("Exit"))
-        self.Bind(wx.EVT_MENU, self.on_exit, exit_item)
+        self.frame.Bind(wx.EVT_MENU, self.on_exit, exit_item)
 
         return menu
 
@@ -211,17 +358,7 @@ class KolibriTaskBarIcon(TaskBarIcon):
             # WebView2 is available, show/create the main window
             main_window = self.app.view
             if main_window:
-                view = main_window.view
-                # If window is minimized, make it non-minimized.
-                if view.IsIconized():
-                    view.Iconize(False)
-
-                # If the window is closed, show it.
-                if not view.IsShown():
-                    view.Show()
-
-                # Always bring the window to the foreground.
-                view.Raise()
+                self._show_window(main_window)
             else:
                 # Create new window
                 self.app.create_kolibri_window()
@@ -345,3 +482,22 @@ class KolibriTaskBarIcon(TaskBarIcon):
 
         # Exit the main loop
         self.app.ExitMainLoop()
+
+    def Destroy(self):
+        """Remove the tray icon, restore the window proc, and destroy the frame."""
+        self._remove_icon()
+        for hicon in (self._tray_hicon, self._balloon_hicon):
+            if hicon:
+                win32gui.DestroyIcon(hicon)
+        self._tray_hicon = self._balloon_hicon = None
+        if self._old_wndproc is not None:
+            try:
+                win32gui.SetWindowLong(
+                    self.hwnd, win32con.GWL_WNDPROC, self._old_wndproc
+                )
+            except pywintypes.error:
+                pass
+            self._old_wndproc = None
+        if self.frame:
+            self.frame.Destroy()
+            self.frame = None

--- a/src/kolibri_app/windows/taskbar_icon.py
+++ b/src/kolibri_app/windows/taskbar_icon.py
@@ -36,12 +36,14 @@ import winerror
 import wx
 
 from kolibri_app.constants import APP_NAME
+from kolibri_app.constants import APP_USER_MODEL_ID
 from kolibri_app.constants import SERVICE_NAME
 from kolibri_app.constants import TRAY_ICON_ICO
 from kolibri_app.i18n import _
 from kolibri_app.logger import logging
 from kolibri_app.windows_registry import is_ui_startup_enabled
 from kolibri_app.windows_registry import is_webview2_installed
+from kolibri_app.windows_registry import register_app_user_model_id
 from kolibri_app.windows_registry import set_ui_startup_enabled
 
 DEFAULT_NOTIFICATION_TIMEOUT = 5
@@ -161,6 +163,15 @@ class KolibriTaskBarIcon:
         self._tray_hicon = None
         self._balloon_hicon = None
 
+        # Give the process an explicit, registered AppUserModelID before the
+        # tray icon exists, so notification toasts are attributed to "Kolibri"
+        # with the icon rendered from the .ico file. The shell's fallback — an
+        # auto-generated identity with an icon extracted from the tray HICON —
+        # titles toasts "KolibriApp.exe" and can render the cached icon with
+        # swapped colours (issue #184).
+        self._icon_path = self._resolve_icon_path()
+        self._set_app_identity()
+
         # Hidden window that owns the tray icon and receives its callback
         # messages. Never shown; FRAME_NO_TASKBAR keeps it off the taskbar.
         self.frame = wx.Frame(None, title=f"{APP_NAME}_Tray", style=wx.FRAME_NO_TASKBAR)
@@ -175,6 +186,28 @@ class KolibriTaskBarIcon:
         self._load_icons()
         self._add_icon()
 
+    def _resolve_icon_path(self):
+        """Return the absolute path of the app icon, or None if unavailable."""
+        try:
+            return str((files("kolibri_app") / TRAY_ICON_ICO).resolve())
+        except OSError as e:
+            logging.error(f"Error resolving tray icon path: {e}")
+            return None
+
+    def _set_app_identity(self):
+        """Register and adopt the explicit AppUserModelID for this process."""
+        if not self._icon_path:
+            return
+        if not register_app_user_model_id(self._icon_path):
+            return
+        result = ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(
+            APP_USER_MODEL_ID
+        )
+        if result != 0:
+            logging.error(
+                f"SetCurrentProcessExplicitAppUserModelID failed with HRESULT {result:#x}"
+            )
+
     def _load_icon(self, path, size):
         """Load the app icon from `path` at the requested pixel size."""
         return win32gui.LoadImage(
@@ -183,11 +216,12 @@ class KolibriTaskBarIcon:
 
     def _load_icons(self):
         """Load the small tray icon and the larger balloon icon."""
+        if not self._icon_path:
+            return
         try:
-            icon_path = str((files("kolibri_app") / TRAY_ICON_ICO).resolve())
             small = win32api.GetSystemMetrics(win32con.SM_CXSMICON)
-            self._tray_hicon = self._load_icon(icon_path, small)
-            self._balloon_hicon = self._load_icon(icon_path, BALLOON_ICON_SIZE)
+            self._tray_hicon = self._load_icon(self._icon_path, small)
+            self._balloon_hicon = self._load_icon(self._icon_path, BALLOON_ICON_SIZE)
         except (OSError, pywintypes.error) as e:
             logging.error(f"Error loading tray icons: {e}")
 

--- a/src/kolibri_app/windows_registry.py
+++ b/src/kolibri_app/windows_registry.py
@@ -11,10 +11,14 @@ import sys
 import winreg
 
 from kolibri_app.constants import APP_NAME
+from kolibri_app.constants import APP_USER_MODEL_ID
 from kolibri_app.constants import WEBVIEW2_RUNTIME_GUID
 
 # Path for current user's startup programs
 REG_KEY_STARTUP_CURRENT_USER = r"Software\Microsoft\Windows\CurrentVersion\Run"
+
+# Per-user registration of the app's AppUserModelID for notifications
+REG_KEY_APP_USER_MODEL_ID = rf"Software\Classes\AppUserModelId\{APP_USER_MODEL_ID}"
 
 # Path for system-wide startup programs
 REG_KEY_STARTUP_ALL_USERS = r"SOFTWARE\Microsoft\Windows\CurrentVersion\Run"
@@ -45,6 +49,25 @@ def is_webview2_installed():
         except (FileNotFoundError, OSError):
             continue
     return False
+
+
+def register_app_user_model_id(icon_path):
+    """Register the app's AppUserModelID with a display name and icon file.
+
+    Notification toasts attributed to this AUMID show DisplayName and render
+    IconUri straight from the file, instead of the shell's auto-generated
+    identity ("KolibriApp.exe" plus a cached tray-icon bitmap).
+    """
+    try:
+        with winreg.CreateKey(
+            winreg.HKEY_CURRENT_USER, REG_KEY_APP_USER_MODEL_ID
+        ) as key:
+            winreg.SetValueEx(key, "DisplayName", 0, winreg.REG_SZ, APP_NAME)
+            winreg.SetValueEx(key, "IconUri", 0, winreg.REG_SZ, icon_path)
+        return True
+    except OSError as e:
+        logging.error(f"Failed to register AppUserModelId: {e}")
+        return False
 
 
 def is_ui_startup_enabled():


### PR DESCRIPTION
## Summary

Fixes #184 — Kolibri icon rendered with swapped colours (yellow↔blue) in Windows notifications on light theme.

Two defects, two fixes:

- **Balloon body icon**: `wx.adv.TaskBarIcon.ShowBalloon` cannot pass a balloon icon, so the shell rasterizes the tray `HICON` through a legacy path that mangles colours. Replaced with a direct `Shell_NotifyIcon` implementation (ctypes `NOTIFYICONDATAW`) sending `NIIF_USER | NIIF_LARGE_ICON` with a 128px `hBalloonIcon`.
- **Toast header**: without an explicit AppUserModelID the shell auto-generates one — header reads "KolibriApp.exe" with a colour-swapped, cached extraction of the tray `HICON`. Now registers `HKCU\Software\Classes\AppUserModelId` with `DisplayName`/`IconUri` and adopts it via `SetCurrentProcessExplicitAppUserModelID`.

The `.ico` encoding is not a factor: PNG- and BMP-encoded entries render identically through both paths.

## Testing
On-device with this branch's CI build installed:

- toast header reads "Kolibri"
- header icon renders correct colours
- body icon renders correct colours

## Screenshots

Before (prior commit):

<img src="https://i.imgur.com/dLaefCj.png" width="600" alt="Before">

After (this build):

<img src="https://i.imgur.com/9D2SRGJ.png" width="600" alt="After">

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpzCncQjENrZafLJVS4EfE