### PR TITLE
Consolidate server-process implementations; fix OS auto-login + Windows print

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,5 @@ installer/nssm.exe
 update_report.txt
 installer/dist-installer/
 installer/translations/locale/*/*.isl
+# WebView2 SDK extracted by scripts/extract_webview2_iids.py for vtable layout
+webview2_sdk/

--- a/scripts/extract_webview2_iids.py
+++ b/scripts/extract_webview2_iids.py
@@ -1,0 +1,77 @@
+"""
+Developer utility: parse Microsoft's WebView2.h to extract the IID and vtable
+layout of each ICoreWebView2_N interface. Used to derive the constants in
+``src/kolibri_app/webview2_native.py`` (e.g. SHOWPRINTUI_VTBL_INDEX).
+
+Re-run this only when adding native COM calls for newer WebView2 features.
+
+Pre-requisite: the WebView2 SDK headers must be present at
+``webview2_sdk/build/native/include/WebView2.h`` (gitignored). Fetch with::
+
+    curl -L -o /tmp/wv2.nupkg \\
+        https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/1.0.3912.50
+    unzip -o /tmp/wv2.nupkg -d webview2_sdk/
+
+The ``DECLSPEC_XFGVIRT(OwnerInterface, MethodName)`` annotations in the
+C-style ICoreWebView2_NVtbl struct give us the authoritative ordered slot
+list (including inherited slots) per interface.
+"""
+import re
+
+HEADER = "webview2_sdk/build/native/include/WebView2.h"
+
+with open(HEADER, encoding="utf-8") as f:
+    text = f.read()
+
+# IIDs
+IID_RE = re.compile(
+    r"EXTERN_C\s+__declspec\(selectany\)\s+const\s+IID\s+IID_(ICoreWebView2(?:_\d+)?)\s*=\s*\{0x([0-9A-Fa-f]+),0x([0-9A-Fa-f]+),0x([0-9A-Fa-f]+),\{([^}]+)\}\};"
+)
+iids = {}
+for m in IID_RE.finditer(text):
+    name = m.group(1)
+    g1, g2, g3 = m.group(2), m.group(3), m.group(4)
+    rest = m.group(5).replace("0x", "").replace(" ", "")
+    parts = rest.split(",")
+    iid = (
+        f"{int(g1, 16):08X}-"
+        f"{int(g2, 16):04X}-"
+        f"{int(g3, 16):04X}-"
+        f"{parts[0].zfill(2)}{parts[1].zfill(2)}-"
+        f"{''.join(p.zfill(2) for p in parts[2:8])}"
+    ).upper()
+    iids[name] = iid
+
+# Vtable structs: typedef struct ICoreWebView2_NVtbl { ... DECLSPEC_XFGVIRT(Owner, Method) ... } ICoreWebView2_NVtbl;
+VTBL_NAME_RE = re.compile(
+    r"typedef\s+struct\s+(ICoreWebView2(?:_\d+)?)Vtbl\s*\{([\s\S]*?)\}\s*\1Vtbl\s*;"
+)
+SLOT_RE = re.compile(r"DECLSPEC_XFGVIRT\(\s*(\w+)\s*,\s*(\w+)\s*\)")
+
+vtables = {}
+for m in VTBL_NAME_RE.finditer(text):
+    name = m.group(1)
+    body = m.group(2)
+    vtables[name] = SLOT_RE.findall(body)
+
+print(f"{'Interface':<22}{'IID':<40}{'vtable slots':>14}")
+print("-" * 80)
+for name in sorted(
+    iids, key=lambda n: (0 if n == "ICoreWebView2" else int(n.rsplit("_", 1)[1]))
+):
+    slots = vtables.get(name, [])
+    print(f"{name:<22}{iids.get(name, '?'):<40}{len(slots):>14}")
+
+# Verify ICoreWebView2_16 layout: ShowPrintUI should be present with owner ICoreWebView2_16
+target = "ICoreWebView2_16"
+print()
+print(f"Last 6 slots of {target}:")
+for i, (owner, method) in enumerate(vtables[target][-6:]):
+    idx = len(vtables[target]) - 6 + i
+    print(f"  [{idx:>3}] {owner}::{method}")
+
+# Show position of ShowPrintUI in ICoreWebView2_16
+for i, (owner, method) in enumerate(vtables[target]):
+    if method == "ShowPrintUI":
+        print(f"\nShowPrintUI vtable index in ICoreWebView2_16: {i}")
+        break

--- a/src/kolibri_app/application.py
+++ b/src/kolibri_app/application.py
@@ -20,7 +20,7 @@ if WINDOWS:
     import win32gui
     import ctypes
 else:
-    from kolibri_app.server_manager_posix import PosixServerManager as ServerManager
+    from kolibri_app.server_manager_posix import PosixKolibriProcess as ServerManager
     from kolibri.core.device.utils import app_initialize_url
 
 STATE_FILE = "app_state.json"

--- a/src/kolibri_app/application.py
+++ b/src/kolibri_app/application.py
@@ -260,7 +260,9 @@ class KolibriApp(wx.App):
             final_url = f"{root_url}?next={next_url}" if next_url else root_url
         else:
             # On other platforms, we construct the URL ourselves
-            final_url = self.kolibri_origin + app_initialize_url(next_url=next_url)
+            final_url = self.kolibri_origin + app_initialize_url(
+                auth_token=self.server_manager.auth_token, next_url=next_url
+            )
         self.kolibri_url = final_url
         logging.info(f"Loading Kolibri at: {final_url}")
 

--- a/src/kolibri_app/kolibri_plugin.py
+++ b/src/kolibri_app/kolibri_plugin.py
@@ -1,4 +1,5 @@
 import getpass
+import hmac
 
 from kolibri.core.device.hooks import GetOSUserHook
 from kolibri.plugins import KolibriPluginBase
@@ -11,12 +12,22 @@ class KolibriApp(KolibriPluginBase):
 
 @register_hook
 class KolibriAppGetOSUserHook(GetOSUserHook):
+    # Set once per app launch by KolibriProcess. Without the comparison, any
+    # localhost client holding the (separate) device app key would be auto-
+    # logged in as the desktop OS user.
+    expected_auth_token = None
+
     def get_os_user(self, auth_token):
+        expected = self.expected_auth_token
+        if (
+            expected is None
+            or not auth_token
+            or not hmac.compare_digest(auth_token, expected)
+        ):
+            return (None, False)
+
         try:
             username = getpass.getuser()
-        except Exception:
-            username = None
-
-        if username:
-            return (username, True)
-        return (None, False)
+        except OSError:
+            return (None, False)
+        return (username, True)

--- a/src/kolibri_app/kolibri_process.py
+++ b/src/kolibri_app/kolibri_process.py
@@ -7,11 +7,13 @@ across platform-specific implementations.
 Platform-specific behavior is achieved by adding different plugins to the same
 base process class, rather than having separate wrapper classes per platform.
 """
+import secrets
 
 from kolibri.main import initialize
 from kolibri.utils.conf import OPTIONS
 from kolibri.utils.server import KolibriProcessBus
 
+from kolibri_app.kolibri_plugin import KolibriAppGetOSUserHook
 from kolibri_app.logger import logging
 
 
@@ -30,6 +32,13 @@ class KolibriProcess(KolibriProcessBus):
     def __init__(self, port=None, zip_port=None):
         logging.info("Initializing Kolibri...")
         initialize()
+
+        # Per-launch shared secret. The token round-trips through
+        # InitializeAppView (URL query) -> APP_AUTH_TOKEN_COOKIE -> provisioning
+        # validator -> KolibriAppGetOSUserHook, which compares it against the
+        # expected value before returning the desktop OS user.
+        self.auth_token = secrets.token_urlsafe(32)
+        KolibriAppGetOSUserHook.expected_auth_token = self.auth_token
 
         if port is None:
             port = OPTIONS["Deployment"]["HTTP_PORT"]

--- a/src/kolibri_app/kolibri_process.py
+++ b/src/kolibri_app/kolibri_process.py
@@ -1,0 +1,41 @@
+"""Unified Kolibri Process Implementation
+
+This module provides a unified KolibriProcess class that directly inherits from
+KolibriProcessBus, consolidating initialization logic that was previously duplicated
+across platform-specific implementations.
+
+Platform-specific behavior is achieved by adding different plugins to the same
+base process class, rather than having separate wrapper classes per platform.
+"""
+
+from kolibri.main import initialize
+from kolibri.utils.conf import OPTIONS
+from kolibri.utils.server import KolibriProcessBus
+
+from kolibri_app.logger import logging
+
+
+class KolibriProcess(KolibriProcessBus):
+    """
+    Unified Kolibri server process that directly inherits from KolibriProcessBus.
+
+    This class consolidates the initialization logic previously duplicated across
+    Windows and POSIX implementations, reducing code duplication and providing
+    a single source of truth for Kolibri server setup.
+
+    Platform-specific behavior is achieved by adding different plugins after
+    construction, rather than through inheritance or wrapper classes.
+    """
+
+    def __init__(self, port=None, zip_port=None):
+        logging.info("Initializing Kolibri...")
+        initialize()
+
+        if port is None:
+            port = OPTIONS["Deployment"]["HTTP_PORT"]
+        if zip_port is None:
+            zip_port = OPTIONS["Deployment"]["ZIP_CONTENT_PORT"]
+
+        super().__init__(port=port, zip_port=zip_port)
+
+        logging.info(f"KolibriProcess initialized on port {port}")

--- a/src/kolibri_app/server_manager_posix.py
+++ b/src/kolibri_app/server_manager_posix.py
@@ -1,53 +1,63 @@
 from threading import Thread
 
-from kolibri.main import initialize
-from kolibri.utils.conf import OPTIONS
-from kolibri.utils.server import KolibriProcessBus
 from magicbus.plugins import SimplePlugin
 
+from kolibri_app.kolibri_process import KolibriProcess
 from kolibri_app.logger import logging
 
 
 class AppPlugin(SimplePlugin):
+    """
+    MagicBus plugin for POSIX platforms that handles the SERVING event.
+
+    This plugin subscribes to the Kolibri server's SERVING event and invokes
+    a callback when the server is ready, allowing the UI to load Kolibri.
+    """
+
     def __init__(self, bus, callback):
-        self.bus = bus
+        super().__init__(bus)
         self.callback = callback
+        # Subscribe to SERVING event (not part of plugin.subscribe())
         self.bus.subscribe("SERVING", self.SERVING)
 
     def SERVING(self, port):
+        """Handle the SERVING event by invoking the callback with port info."""
         self.callback(port, root_url=None)
 
 
-class PosixServerManager:
+class PosixKolibriProcess(KolibriProcess):
     """
-    Manages the Kolibri server for non-Windows platforms (macOS, Linux)
-    by running it in a separate thread within the same process.
+    POSIX-specific Kolibri process that runs in a daemon thread.
+
+    This class inherits from KolibriProcess and adds the AppPlugin for
+    direct callback communication with the main application. It manages
+    its own threading to run the server in a separate thread within the
+    same process.
     """
 
     def __init__(self, app):
-        self.app = app
-        self.kolibri_server = None
+        super().__init__()
+
+        self.app_plugin = AppPlugin(self, app.load_kolibri)
+        self.app_plugin.subscribe()
+
         self.server_thread = None
 
     def start(self):
+        """
+        Start the Kolibri server in a daemon thread.
+
+        This method spawns a background thread that runs the server's
+        event loop, allowing the main thread to continue managing the UI.
+        """
         if self.server_thread:
             return
 
         logging.info("Preparing to start Kolibri server thread")
-        self.server_thread = Thread(target=self._run_kolibri_server)
+        self.server_thread = Thread(target=self.run)
         self.server_thread.daemon = True
         self.server_thread.start()
 
-    def _run_kolibri_server(self):
-        initialize()
-
-        self.kolibri_server = KolibriProcessBus(
-            port=OPTIONS["Deployment"]["HTTP_PORT"],
-            zip_port=OPTIONS["Deployment"]["ZIP_CONTENT_PORT"],
-        )
-        AppPlugin(self.kolibri_server, self.app.load_kolibri)
-        self.kolibri_server.run()
-
     def shutdown(self):
-        if self.kolibri_server is not None:
-            self.kolibri_server.transition("EXITED")
+        """Shutdown the Kolibri server by transitioning to EXITED state."""
+        self.transition("EXITED")

--- a/src/kolibri_app/server_process_windows.py
+++ b/src/kolibri_app/server_process_windows.py
@@ -85,7 +85,7 @@ class WindowsIpcPlugin(SimplePlugin):
         Construct the server URLs based on the port.
         """
         kolibri_origin = f"http://localhost:{port}"
-        root_url = kolibri_origin + app_initialize_url()
+        root_url = kolibri_origin + app_initialize_url(auth_token=self.bus.auth_token)
         return kolibri_origin, root_url
 
     def on_server_start(self, port):

--- a/src/kolibri_app/server_process_windows.py
+++ b/src/kolibri_app/server_process_windows.py
@@ -1,12 +1,12 @@
 """Windows Server Subprocess Implementation
 
 This module implements the Kolibri server that runs as a separate subprocess on Windows.
-It uses a MagicBus plugin (`WindowsIpcPlugin`) integrated with `KolibriProcessBus`
+It uses a MagicBus plugin (`WindowsIpcPlugin`) integrated with `KolibriProcess`
 to manage Inter-Process Communication (IPC) with the main UI process via a named pipe.
 
 Architecture Overview:
 - The main UI process spawns this module as a subprocess with the --run-as-server flag.
-- `ServerProcess` initializes Kolibri and the `KolibriProcessBus`.
+- `run_windows_server()` creates a `KolibriProcess` and adds the Windows IPC plugin.
 - The `WindowsIpcPlugin` is subscribed to the bus. On its `START` event, it creates
   a named pipe and listens for a connection from the UI process in a background thread.
 - When the Kolibri server is ready, it fires a 'SERVING' event. The plugin
@@ -36,11 +36,11 @@ if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
     sys.path.insert(0, os.path.join(sys._MEIPASS, "kolibrisrc"))
     sys.path.insert(0, os.path.join(sys._MEIPASS, "kolibrisrc", "kolibri", "dist"))
 
-from kolibri.main import initialize
 from kolibri.core.device.utils import app_initialize_url
-from kolibri.utils.conf import OPTIONS
-from kolibri.utils.server import KolibriProcessBus
+
+from kolibri_app.kolibri_process import KolibriProcess
 from kolibri_app.logger import logging
+
 
 # Named pipe for IPC between UI process and server subprocess
 # Uses Windows named pipe format: \\.<hostname>\pipe\<pipename>
@@ -271,52 +271,17 @@ class WindowsIpcPlugin(SimplePlugin):
         logging.info("Pipe server thread finished.")
 
 
-class ServerProcess:
+class WindowsKolibriProcess(KolibriProcess):
     """
-    Main server process coordinator for Windows subprocess implementation.
-    Manages the Kolibri server initialization and runs it with the IPC plugin.
+    Windows-specific Kolibri process with IPC plugin for named pipe communication.
+
+    This class is used in the Windows server subprocess (spawned with --run-as-server).
+    It inherits from KolibriProcess and adds the WindowsIpcPlugin for communication
+    with the main UI process via named pipes.
     """
 
     def __init__(self):
-        self.kolibri_server = None
+        super().__init__()
 
-    def _initialize_kolibri(self):
-        """
-        Initialize Kolibri with required plugins and configuration.
-        """
-        logging.info("Server process: Initializing Kolibri...")
-        initialize()
-
-    def _create_kolibri_server(self):
-        """
-        Create and configure the Kolibri server instance.
-        """
-        return KolibriProcessBus(
-            port=OPTIONS["Deployment"]["HTTP_PORT"],
-            zip_port=OPTIONS["Deployment"]["ZIP_CONTENT_PORT"],
-        )
-
-    def _setup_ipc_plugin(self):
-        """
-        Create and subscribe the IPC plugin to the server.
-        """
-        ipc_plugin = WindowsIpcPlugin(self.kolibri_server)
-        ipc_plugin.subscribe()
-        return ipc_plugin
-
-    def run(self):
-        """
-        Main server process entry point, initializes and runs Kolibri server.
-        The server runs until terminated by the Job Object or explicit shutdown.
-        """
-        try:
-            self._initialize_kolibri()
-            self.kolibri_server = self._create_kolibri_server()
-            self._setup_ipc_plugin()
-
-            logging.info("Server process: Starting Kolibri server...")
-            # Start serving, this blocks until shutdown
-            self.kolibri_server.run()
-        except (ImportError, OSError, RuntimeError, ValueError) as e:
-            logging.error(f"Server process error: {e}", exc_info=True)
-            sys.exit(1)
+        self.ipc_plugin = WindowsIpcPlugin(self)
+        self.ipc_plugin.subscribe()

--- a/src/kolibri_app/view.py
+++ b/src/kolibri_app/view.py
@@ -16,7 +16,14 @@ from kolibri_app.i18n import _
 from kolibri_app.i18n import locale_info
 from kolibri_app.logger import logging
 
+if WINDOWS:
+    from kolibri_app import webview2_native
+
 LOADER_PAGE = "loading.html"
+
+# JS->Python bridge for hijacking window.print() on Windows; see __init__.
+BRIDGE_NAME = "kolibriBridge"
+BRIDGE_MSG_PRINT = "print"
 
 ZOOM_LEVELS = [
     html2.WEBVIEW_ZOOM_TINY,
@@ -69,6 +76,10 @@ class KolibriView(object):
         self.webview = html2.WebView.New(self.view, backend=backend)
         self.webview.Bind(html2.EVT_WEBVIEW_NAVIGATING, self.OnBeforeLoad)
         self.webview.Bind(html2.EVT_WEBVIEW_LOADED, self.OnLoadComplete)
+
+        self._print_pending = False
+
+        self._setup_printing()
 
         if url is None:
             # If no URL is provided, show the loading screen directly.
@@ -178,6 +189,26 @@ class KolibriView(object):
 
         self.view.SetMenuBar(menu_bar)
 
+    def _setup_printing(self):
+        if WINDOWS:
+            # JS-initiated window.print() is a no-op in WebView2 hosted via
+            # wxPython's html2 backend; intercept and route to
+            # ICoreWebView2_16::ShowPrintUI via webview2_native. Other backends
+            # surface window.print() to a real dialog without help.
+            if self.webview.AddScriptMessageHandler(BRIDGE_NAME):
+                self.webview.AddUserScript(
+                    f"window.print = function () {{"
+                    f" window.{BRIDGE_NAME}.postMessage('{BRIDGE_MSG_PRINT}');"
+                    f"}};",
+                    injectionTime=html2.WEBVIEW_INJECT_AT_DOCUMENT_START,
+                )
+                self.webview.Bind(
+                    html2.EVT_WEBVIEW_SCRIPT_MESSAGE_RECEIVED,
+                    self.OnScriptMessage,
+                )
+            else:
+                logging.warning(f"Failed to register {BRIDGE_NAME} script handler")
+
     def add_menu_item(self, menu, title, handler=None, item_id=None):
         item_id = item_id or wx.NewId()
         item = menu.Append(item_id, title)
@@ -223,6 +254,32 @@ class KolibriView(object):
     def OnBeforeLoad(self, event):
         if not self.app.should_load_url(event.URL):
             event.Veto()
+
+    def OnScriptMessage(self, event):
+        message = event.GetString()
+        if message == BRIDGE_MSG_PRINT:
+            # Defer so we leave the WebView2 message callback before re-entering
+            # the COM object. Coalesce rapid-fire calls (e.g. JS in a loop) so
+            # we only enqueue one dialog.
+            if self._print_pending:
+                return
+            self._print_pending = True
+            wx.CallAfter(self.show_print_dialog)
+        else:
+            logging.warning(f"Unhandled {BRIDGE_NAME} message: {message!r}")
+
+    def show_print_dialog(self):
+        self._print_pending = False
+        if WINDOWS:
+            try:
+                webview2_native.show_print_ui(
+                    self.webview.GetNativeBackend(),
+                    webview2_native.PRINT_DIALOG_KIND_BROWSER,
+                )
+            except OSError as e:
+                logging.warning(f"Native ShowPrintUI failed: {e}")
+        else:
+            self.webview.Print()
 
     def OnLoadComplete(self, event):
         # Make sure that any attempts to use back functionality don't take us back to the loading screen

--- a/src/kolibri_app/webview2_native.py
+++ b/src/kolibri_app/webview2_native.py
@@ -1,0 +1,120 @@
+"""
+Direct COM access to the WebView2 control underlying ``wx.html2.WebView``
+on Windows. Used to call ``ICoreWebView2_16::ShowPrintUI`` since
+wxPython 4.2.2's ``WebView.Print()`` is a no-op on the Edge backend (it
+predates the SDK version that introduced ShowPrintUI).
+
+We use raw ctypes against the COM vtable rather than comtypes to keep the
+dependency surface minimal. The vtable layout below was extracted from
+WebView2.h (Microsoft.Web.WebView2 NuGet package); see
+``scripts/extract_webview2_iids.py`` for how to regenerate it.
+"""
+import ctypes
+
+
+HRESULT = ctypes.c_int  # 32-bit signed
+LPVOID = ctypes.c_void_p
+
+
+class GUID(ctypes.Structure):
+    _fields_ = [
+        ("Data1", ctypes.c_uint32),
+        ("Data2", ctypes.c_uint16),
+        ("Data3", ctypes.c_uint16),
+        ("Data4", ctypes.c_ubyte * 8),
+    ]
+
+
+def _guid(d1, d2, d3, *d4):
+    g = GUID()
+    g.Data1 = d1
+    g.Data2 = d2
+    g.Data3 = d3
+    for i, b in enumerate(d4):
+        g.Data4[i] = b
+    return g
+
+
+# ICoreWebView2_16 — adds Print, ShowPrintUI, PrintToPdfStream.
+# Available at runtime in any WebView2 Runtime >= 1.0.1518.46 (mid-2022).
+IID_ICoreWebView2_16 = _guid(
+    0x0EB34DC9,
+    0x9F91,
+    0x41E1,
+    0x86,
+    0x39,
+    0x95,
+    0xCD,
+    0x59,
+    0x43,
+    0x90,
+    0x6B,
+)
+
+# Vtable slot of ShowPrintUI on ICoreWebView2_16 (zero-based, includes the
+# three IUnknown slots). Don't change without re-running
+# scripts/extract_webview2_iids.py.
+SHOWPRINTUI_VTBL_INDEX = 114
+
+# COREWEBVIEW2_PRINT_DIALOG_KIND
+PRINT_DIALOG_KIND_BROWSER = 0  # WebView2's in-page print preview overlay
+PRINT_DIALOG_KIND_SYSTEM = 1  # OS print dialog (separate window)
+
+
+# Function prototypes for raw vtable invocation. WINFUNCTYPE = stdcall.
+_PFN_QueryInterface = ctypes.WINFUNCTYPE(
+    HRESULT,
+    LPVOID,  # this
+    ctypes.POINTER(GUID),  # riid
+    ctypes.POINTER(LPVOID),  # ppvObject
+)
+_PFN_Release = ctypes.WINFUNCTYPE(ctypes.c_ulong, LPVOID)
+_PFN_ShowPrintUI = ctypes.WINFUNCTYPE(HRESULT, LPVOID, ctypes.c_int)
+
+
+_PTR_SIZE = ctypes.sizeof(LPVOID)
+
+
+def _vtable_slot(this_ptr, index):
+    """Read pointer at vtbl[index] of the COM object at ``this_ptr``."""
+    vtbl_addr = LPVOID.from_address(this_ptr).value
+    fn_addr = LPVOID.from_address(vtbl_addr + index * _PTR_SIZE).value
+    return fn_addr
+
+
+def _query_interface(this_ptr, iid):
+    """Call IUnknown::QueryInterface; return the new interface pointer (int)."""
+    qi_fn = _PFN_QueryInterface(_vtable_slot(this_ptr, 0))
+    out = LPVOID()
+    hr = qi_fn(this_ptr, ctypes.byref(iid), ctypes.byref(out))
+    if hr != 0 or not out.value:
+        raise OSError(f"QueryInterface failed (hr=0x{hr & 0xFFFFFFFF:08X})")
+    return out.value
+
+
+def _release(this_ptr):
+    fn = _PFN_Release(_vtable_slot(this_ptr, 2))
+    return fn(this_ptr)
+
+
+def show_print_ui(native_backend_ptr, dialog_kind=PRINT_DIALOG_KIND_BROWSER):
+    """Open the WebView2 print UI for the given native backend pointer.
+
+    ``native_backend_ptr`` is the integer returned by
+    ``wx.html2.WebView.GetNativeBackend()`` on the Edge backend, where it is
+    an ``ICoreWebView2_2*``. We QI for ``ICoreWebView2_16`` (introduced in
+    a later runtime than wxWidgets 3.2.x targets) and invoke ShowPrintUI.
+    """
+    # wxPython hands the native backend back as a sip.voidptr; coerce to int.
+    ptr = int(native_backend_ptr) if native_backend_ptr else 0
+    if not ptr:
+        raise ValueError("native_backend_ptr is null")
+
+    iface16 = _query_interface(ptr, IID_ICoreWebView2_16)
+    try:
+        fn = _PFN_ShowPrintUI(_vtable_slot(iface16, SHOWPRINTUI_VTBL_INDEX))
+        hr = fn(iface16, dialog_kind)
+        if hr != 0:
+            raise OSError(f"ShowPrintUI failed (hr=0x{hr & 0xFFFFFFFF:08X})")
+    finally:
+        _release(iface16)

--- a/src/kolibri_app/windows_utils.py
+++ b/src/kolibri_app/windows_utils.py
@@ -5,7 +5,7 @@ import win32service
 
 from kolibri_app.constants import SERVICE_NAME
 from kolibri_app.logger import logging
-from kolibri_app.server_process_windows import ServerProcess
+from kolibri_app.server_process_windows import WindowsKolibriProcess
 from kolibri_app.windows_registry import update_tray_icon_startup
 
 
@@ -89,6 +89,6 @@ def handle_windows_commands():
     # This block is the entry point for the server subprocess
     if "--run-as-server" in sys.argv:
         logging.info("Starting in server mode...")
-        server = ServerProcess()
+        server = WindowsKolibriProcess()
         server.run()
         sys.exit(0)


### PR DESCRIPTION
## Summary

1. **Consolidate `ServerProcess` + `PosixServerManager` into a single `KolibriProcess` base** with thin platform subclasses. Closes #202.

2. **Validate `auth_token` in `KolibriAppGetOSUserHook`** before returning the OS user. The hook previously accepted any non-empty token on both platforms, so a localhost client holding the (separate) device app key could auto-login as the desktop OS user. Token is now generated once per server-process launch, stamped on the hook class, and checked with `hmac.compare_digest`. Wiring the same token through `app_initialize_url` also fixes first-run provisioning failing with `Either superuser or auth_token must be provided`.

3. **Route `window.print()` through `ICoreWebView2_16::ShowPrintUI`** on Windows. wxPython 4.2.2's bundled WebView2 SDK predates this method and doesn't surface `window.print()` to a dialog. New `webview2_native.py` is a raw-ctypes COM shim, no new deps.

## References

- Closes #202 (consolidation)
- Required for learningequality/kolibri#14674
- WebView2 [`ICoreWebView2_16::ShowPrintUI`](https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/icorewebview2_16#showprintui)

## Reviewer guidance

### How to test

**Auto-login + provisioning** (both platforms): fresh install completes and lands you logged in as the OS user.

**Print** (Windows): print/export button, View → Print, and Ctrl+P should all open the WebView2 print preview.

**Consolidation**: app starts and shuts down cleanly on both platforms. On Windows, the NSSM service path still works (toggle "Run on start" in the tray) - this should mostly be covered by the automated smoke tests.

## AI usage

Used Claude Code to pair-debug the print failure, write the raw-ctypes `ICoreWebView2_16` shim, and rebase the branch for #202 onto main (propagating main's parallel `enable_plugin`/`share_file` cleanups into the new `KolibriProcess` rather than leaving them as dead code). Edited the AI's drafts: moved auth-token state onto the hook class, hoisted it to `KolibriProcess` so both platforms share one path, narrowed an `except Exception`, dropped a vestigial `enable_app_plugin` parameter. Verified on Windows by fresh-install provisioning and triggering print from the UI button, View menu, and Ctrl+P.