### PR TITLE
simplify File menu, edit menu on Mac, remove History menu

### DIFF
--- a/src/kolibri_app/view.py
+++ b/src/kolibri_app/view.py
@@ -103,20 +103,18 @@ class KolibriView(object):
 
         menu_bar.Append(file_menu, _("File"))
 
-        edit_menu = wx.Menu()
-        # FIXME: Remove these once the native menu handlers are restored
-        self.add_menu_item(
-            edit_menu, _("Undo\tCtrl+Z"), handler=self.on_undo, item_id=wx.ID_UNDO
-        )
-        self.add_menu_item(
-            edit_menu, _("Redo\tCtrl+Shift+Z"), handler=self.on_redo, item_id=wx.ID_REDO
-        )
-        edit_menu.AppendSeparator()
-        self.add_menu_item(edit_menu, _("Cut\tCtrl+X"), item_id=wx.ID_CUT)
-        self.add_menu_item(edit_menu, _("Copy\tCtrl+C"), item_id=wx.ID_COPY)
-        self.add_menu_item(edit_menu, _("Paste\tCtrl+V"), item_id=wx.ID_PASTE)
-        self.add_menu_item(edit_menu, _("Select All\tCtrl+A"), item_id=wx.ID_SELECTALL)
-        menu_bar.Append(edit_menu, _("Edit"))
+        # manually adding menu items only needed on macOS
+        # windows and linux handle this already
+        # see https://github.com/learningequality/kolibri-app/issues/236
+        if MAC:
+            edit_menu = wx.Menu()
+            self.add_menu_item(edit_menu, _("Cut\tCtrl+X"), item_id=wx.ID_CUT)
+            self.add_menu_item(edit_menu, _("Copy\tCtrl+C"), item_id=wx.ID_COPY)
+            self.add_menu_item(edit_menu, _("Paste\tCtrl+V"), item_id=wx.ID_PASTE)
+            self.add_menu_item(
+                edit_menu, _("Select All\tCtrl+A"), item_id=wx.ID_SELECTALL
+            )
+            menu_bar.Append(edit_menu, _("Edit"))
 
         view_menu = wx.Menu()
         self.add_menu_item(
@@ -262,12 +260,6 @@ class KolibriView(object):
 
     def on_reload(self, event):
         self.webview.Reload()
-
-    def on_undo(self, event):
-        self.webview.Undo()
-
-    def on_redo(self, event):
-        self.webview.Redo()
 
     def on_actual_size(self, event):
         self.webview.SetZoom(html2.WEBVIEW_ZOOM_MEDIUM)

--- a/src/kolibri_app/view.py
+++ b/src/kolibri_app/view.py
@@ -85,16 +85,6 @@ class KolibriView(object):
 
         file_menu = wx.Menu()
         self.add_menu_item(
-            file_menu, _("New Window"), handler=self.on_new_window, item_id=wx.ID_NEW
-        )
-        self.add_menu_item(
-            file_menu,
-            _("Close Window"),
-            handler=self.on_close_window,
-            item_id=wx.ID_CLOSE,
-        )
-        file_menu.AppendSeparator()
-        self.add_menu_item(
             file_menu,
             _("Open Kolibri Home Folder"),
             handler=self.on_open_kolibri_home,
@@ -143,21 +133,6 @@ class KolibriView(object):
             view_menu, _("Open in Browser"), handler=self.on_open_in_browser
         )
         menu_bar.Append(view_menu, _("View"))
-
-        history_menu = wx.Menu()
-        self.add_menu_item(
-            history_menu,
-            _("Back\tCtrl+["),
-            handler=self.on_back,
-            item_id=wx.ID_BACKWARD,
-        )
-        self.add_menu_item(
-            history_menu,
-            _("Forward\tCtrl+]"),
-            handler=self.on_forward,
-            item_id=wx.ID_FORWARD,
-        )
-        menu_bar.Append(history_menu, _("History"))
 
         help_menu = wx.Menu()
         self.add_menu_item(
@@ -235,12 +210,6 @@ class KolibriView(object):
     def on_forums(self, event):
         webbrowser.open("https://community.learningequality.org/")
 
-    def on_new_window(self, event):
-        self.app.create_kolibri_window(url=self.app.kolibri_origin)
-
-    def on_close_window(self, event):
-        self.close()
-
     def on_open_in_browser(self, event):
         webbrowser.open(self.get_url())
 
@@ -251,12 +220,6 @@ class KolibriView(object):
             subprocess.call(["open", os.environ["KOLIBRI_HOME"]])
         elif LINUX:
             subprocess.call(["xdg-open", os.environ["KOLIBRI_HOME"]])
-
-    def on_back(self, event):
-        self.webview.GoBack()
-
-    def on_forward(self, event):
-        self.webview.GoForward()
 
     def on_reload(self, event):
         self.webview.Reload()


### PR DESCRIPTION
## Summary

Fixes https://github.com/learningequality/kolibri-app/issues/232
1) Removes History Menu 
2) Trim file menu 

Window menu updates on MacOS determined in conversation w/ Richard to be out of scope after further investigation with Claude (significant, brittle work arounds were needed. probably not worth the effort for the near term)

Fixes https://github.com/learningequality/kolibri-app/issues/236 
3) 
Small cleanup of edit menu
- relies on system options for windows/linux
- makes the manually added menu specific to macOS
- removes undo/redo 

## References

Simplified menus on Mac app, History no longer included in toolbar

<img width="1142" height="625" alt="Screenshot 2026-06-08 at 9 51 24 AM" src="https://github.com/user-attachments/assets/35f80265-a4ef-4868-8c6d-06aa4fdfcd6c" />
<img width="1087" height="648" alt="Screenshot 2026-06-08 at 9 51 19 AM" src="https://github.com/user-attachments/assets/0e2aee64-4601-49eb-b3f3-2eb143a69c95" />

## Reviewer guidance
- confirm changes across app builds 

## AI usage
Implemented mainly with Claude. I reviewed the code and wrote the comment myself and removed some out of scope changes. I also manually tested on macOS to confirm that the edit menu had the updated list